### PR TITLE
Make theme compatible with Swift

### DIFF
--- a/Dracula.xccolortheme
+++ b/Dracula.xccolortheme
@@ -15,142 +15,180 @@
 
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>DVTConsoleDebuggerInputTextColor</key>
-	<string>0.972549 0.972549 0.94902 1</string>
-	<key>DVTConsoleDebuggerInputTextFont</key>
-	<string>Monaco - 12.0</string>
-	<key>DVTConsoleDebuggerOutputTextColor</key>
-	<string>0.972549 0.972549 0.94902 1</string>
-	<key>DVTConsoleDebuggerOutputTextFont</key>
-	<string>Monaco - 12.0</string>
-	<key>DVTConsoleDebuggerPromptTextColor</key>
-	<string>0.313725 0.980392 0.482353 1</string>
-	<key>DVTConsoleDebuggerPromptTextFont</key>
-	<string>Monaco - 12.0</string>
-	<key>DVTConsoleExectuableInputTextColor</key>
-	<string>0.972549 0.972549 0.94902 1</string>
-	<key>DVTConsoleExectuableInputTextFont</key>
-	<string>Monaco - 12.0</string>
-	<key>DVTConsoleExectuableOutputTextColor</key>
-	<string>0.972549 0.972549 0.94902 1</string>
-	<key>DVTConsoleExectuableOutputTextFont</key>
-	<string>Monaco - 12.0</string>
-	<key>DVTConsoleTextBackgroundColor</key>
-	<string>0.156863 0.164706 0.211765 1</string>
-	<key>DVTConsoleTextInsertionPointColor</key>
-	<string>1 1 1 1</string>
-	<key>DVTConsoleTextSelectionColor</key>
-	<string>0.266667 0.278431 0.352941 1</string>
-	<key>DVTDebuggerInstructionPointerColor</key>
-	<string>0.545098 0.913725 0.992157 1</string>
-	<key>DVTSourceTextBackground</key>
-	<string>0.117658 0.122153 0.159778 1</string>
-	<key>DVTSourceTextBlockDimBackgroundColor</key>
-	<string>0.5 0.5 0.5 1</string>
-	<key>DVTSourceTextInsertionPointColor</key>
-	<string>1 1 1 1</string>
-	<key>DVTSourceTextInvisiblesColor</key>
-	<string>0.496379 0.5 0.5 1</string>
-	<key>DVTSourceTextSelectionColor</key>
-	<string>0.266667 0.278431 0.352941 1</string>
-	<key>DVTSourceTextSyntaxColors</key>
 	<dict>
-		<key>xcode.syntax.attribute</key>
+		<key>DVTConsoleDebuggerInputTextColor</key>
 		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.character</key>
-		<string>0.741176 0.576471 0.976471 1</string>
-		<key>xcode.syntax.comment</key>
-		<string>0.384314 0.447059 0.643137 1</string>
-		<key>xcode.syntax.comment.doc</key>
-		<string>0.384314 0.447059 0.643137 1</string>
-		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>0.384314 0.447059 0.643137 1</string>
-		<key>xcode.syntax.identifier.class</key>
+		<key>DVTConsoleDebuggerInputTextFont</key>
+		<string>Monaco - 12.0</string>
+		<key>DVTConsoleDebuggerOutputTextColor</key>
+		<string>0.972549 0.972549 0.94902 1</string>
+		<key>DVTConsoleDebuggerOutputTextFont</key>
+		<string>Monaco - 12.0</string>
+		<key>DVTConsoleDebuggerPromptTextColor</key>
 		<string>0.313725 0.980392 0.482353 1</string>
-		<key>xcode.syntax.identifier.class.system</key>
+		<key>DVTConsoleDebuggerPromptTextFont</key>
+		<string>Monaco - 12.0</string>
+		<key>DVTConsoleExectuableInputTextColor</key>
 		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.identifier.constant</key>
-		<string>0.313725 0.980392 0.482353 1</string>
-		<key>xcode.syntax.identifier.constant.system</key>
+		<key>DVTConsoleExectuableInputTextFont</key>
+		<string>Monaco - 12.0</string>
+		<key>DVTConsoleExectuableOutputTextColor</key>
+		<string>0.972549 0.972549 0.94902 1</string>
+		<key>DVTConsoleExectuableOutputTextFont</key>
+		<string>Monaco - 12.0</string>
+		<key>DVTConsoleTextBackgroundColor</key>
+		<string>0.156863 0.164706 0.211765 1</string>
+		<key>DVTConsoleTextInsertionPointColor</key>
+		<string>1 1 1 1</string>
+		<key>DVTConsoleTextSelectionColor</key>
+		<string>0.266667 0.278431 0.352941 1</string>
+		<key>DVTDebuggerInstructionPointerColor</key>
 		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.identifier.function</key>
-		<string>0.313725 0.980392 0.482353 1</string>
-		<key>xcode.syntax.identifier.function.system</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.identifier.macro</key>
-		<string>0.945098 0.980392 0.54902 1</string>
-		<key>xcode.syntax.identifier.macro.system</key>
-		<string>0.945098 0.980392 0.54902 1</string>
-		<key>xcode.syntax.identifier.type</key>
-		<string>0.313725 0.980392 0.482353 1</string>
-		<key>xcode.syntax.identifier.type.system</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.identifier.variable</key>
-		<string>0.313725 0.980392 0.482353 1</string>
-		<key>xcode.syntax.identifier.variable.system</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>xcode.syntax.keyword</key>
-		<string>1 0.47451 0.776471 1</string>
-		<key>xcode.syntax.number</key>
-		<string>0.741176 0.576471 0.976471 1</string>
-		<key>xcode.syntax.plain</key>
+		<key>DVTMarkupTextBackgroundColor</key>
+		<string>0.188245 0.192381 0.226996 1</string>
+		<key>DVTMarkupTextBorderColor</key>
+		<string>0.253186 0.25699 0.288836 1</string>
+		<key>DVTMarkupTextCodeFont</key>
+		<string>Monaco - 11.0</string>
+		<key>DVTMarkupTextEmphasisColor</key>
 		<string>0.877929 0.872979 0.878041 1</string>
-		<key>xcode.syntax.preprocessor</key>
-		<string>0.945098 0.980392 0.54902 1</string>
-		<key>xcode.syntax.string</key>
-		<string>0.818459 0.333333 0.333333 1</string>
-		<key>xcode.syntax.url</key>
+		<key>DVTMarkupTextEmphasisFont</key>
+		<string>.AppleSystemUIFontItalic - 11.0</string>
+		<key>DVTMarkupTextInlineCodeColor</key>
+		<string>0.877929 0.872979 0.878041 0.7</string>
+		<key>DVTMarkupTextLinkColor</key>
 		<string>0.384314 0.447059 0.643137 1</string>
+		<key>DVTMarkupTextLinkFont</key>
+		<string>.AppleSystemUIFont - 11.0</string>
+		<key>DVTMarkupTextNormalColor</key>
+		<string>0.877929 0.872979 0.878041 1</string>
+		<key>DVTMarkupTextNormalFont</key>
+		<string>.AppleSystemUIFont - 11.0</string>
+		<key>DVTMarkupTextOtherHeadingColor</key>
+		<string>0.877929 0.872979 0.878041 0.5</string>
+		<key>DVTMarkupTextOtherHeadingFont</key>
+		<string>.AppleSystemUIFont - 15.4</string>
+		<key>DVTMarkupTextPrimaryHeadingColor</key>
+		<string>0.877929 0.872979 0.878041 1</string>
+		<key>DVTMarkupTextPrimaryHeadingFont</key>
+		<string>.AppleSystemUIFont - 26.4</string>
+		<key>DVTMarkupTextSecondaryHeadingColor</key>
+		<string>0.877929 0.872979 0.878041 1</string>
+		<key>DVTMarkupTextSecondaryHeadingFont</key>
+		<string>.AppleSystemUIFont - 19.8</string>
+		<key>DVTMarkupTextStrongColor</key>
+		<string>0.877929 0.872979 0.878041 1</string>
+		<key>DVTMarkupTextStrongFont</key>
+		<string>.AppleSystemUIFontEmphasized - 11.0</string>
+		<key>DVTSourceTextBackground</key>
+		<string>0.156863 0.164706 0.211765 1</string>
+		<key>DVTSourceTextBlockDimBackgroundColor</key>
+		<string>0.5 0.5 0.5 1</string>
+		<key>DVTSourceTextCurrentLineHighlightColor</key>
+		<string>0.266667 0.278431 0.352941 1</string>
+		<key>DVTSourceTextInsertionPointColor</key>
+		<string>1 1 1 1</string>
+		<key>DVTSourceTextInvisiblesColor</key>
+		<string>0.496379 0.5 0.5 1</string>
+		<key>DVTSourceTextSelectionColor</key>
+		<string>0.266667 0.278431 0.352941 1</string>
+		<key>DVTSourceTextSyntaxColors</key>
+		<dict>
+			<key>xcode.syntax.attribute</key>
+			<string>0.313725 0.980392 0.482353 1</string>
+			<key>xcode.syntax.character</key>
+			<string>0.741176 0.576471 0.976471 1</string>
+			<key>xcode.syntax.comment</key>
+			<string>0.384314 0.447059 0.643137 1</string>
+			<key>xcode.syntax.comment.doc</key>
+			<string>0.384314 0.447059 0.643137 1</string>
+			<key>xcode.syntax.comment.doc.keyword</key>
+			<string>0.384314 0.447059 0.643137 1</string>
+			<key>xcode.syntax.identifier.class</key>
+			<string>0.313725 0.980392 0.482353 1</string>
+			<key>xcode.syntax.identifier.class.system</key>
+			<string>0.313725 0.980392 0.482353 1</string>
+			<key>xcode.syntax.identifier.constant</key>
+			<string>0.741176 0.576471 0.976471 1</string>
+			<key>xcode.syntax.identifier.constant.system</key>
+			<string>0.741176 0.576471 0.976471 1</string>
+			<key>xcode.syntax.identifier.function</key>
+			<string>0.313725 0.980392 0.482353 1</string>
+			<key>xcode.syntax.identifier.function.system</key>
+			<string>0.313725 0.980392 0.482353 1</string>
+			<key>xcode.syntax.identifier.macro</key>
+			<string>0.945098 0.980392 0.54902 1</string>
+			<key>xcode.syntax.identifier.macro.system</key>
+			<string>0.945098 0.980392 0.54902 1</string>
+			<key>xcode.syntax.identifier.type</key>
+			<string>1 0.721569 0.423529 1</string>
+			<key>xcode.syntax.identifier.type.system</key>
+			<string>1 0.721569 0.423529 1</string>
+			<key>xcode.syntax.identifier.variable</key>
+			<string>0.545098 0.913725 0.992157 1</string>
+			<key>xcode.syntax.identifier.variable.system</key>
+			<string>0.545098 0.913725 0.992157 1</string>
+			<key>xcode.syntax.keyword</key>
+			<string>1 0.47451 0.776471 1</string>
+			<key>xcode.syntax.number</key>
+			<string>0.741176 0.576471 0.976471 1</string>
+			<key>xcode.syntax.plain</key>
+			<string>0.972549 0.972549 0.94902 1</string>
+			<key>xcode.syntax.preprocessor</key>
+			<string>0.945098 0.980392 0.54902 1</string>
+			<key>xcode.syntax.string</key>
+			<string>0.945098 0.980392 0.54902 1</string>
+			<key>xcode.syntax.url</key>
+			<string>0.741176 0.576471 0.976471 1</string>
+		</dict>
+		<key>DVTSourceTextSyntaxFonts</key>
+		<dict>
+			<key>xcode.syntax.attribute</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.character</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.comment</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.comment.doc</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.comment.doc.keyword</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.class</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.class.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.constant</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.constant.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.function</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.function.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.macro</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.macro.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.type</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.type.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.variable</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.identifier.variable.system</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.keyword</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.number</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.plain</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.preprocessor</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.string</key>
+			<string>Monaco - 12.0</string>
+			<key>xcode.syntax.url</key>
+			<string>Monaco - 12.0</string>
+		</dict>
 	</dict>
-	<key>DVTSourceTextSyntaxFonts</key>
-	<dict>
-		<key>xcode.syntax.attribute</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.character</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.comment</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.comment.doc</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.class</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.class.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.constant</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.constant.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.function</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.function.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.macro</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.macro.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.type</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.type.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.variable</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.identifier.variable.system</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.keyword</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.number</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.plain</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.preprocessor</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.string</key>
-		<string>Monaco - 12.0</string>
-		<key>xcode.syntax.url</key>
-		<string>Monaco - 12.0</string>
-	</dict>
-</dict>
-</plist>
+	</plist>

--- a/Dracula.xccolortheme
+++ b/Dracula.xccolortheme
@@ -15,180 +15,180 @@
 
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0.545098 0.913725 0.992157 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Monaco - 12.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0.972549 0.972549 0.94902 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Monaco - 12.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.313725 0.980392 0.482353 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Monaco - 12.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0.545098 0.913725 0.992157 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Monaco - 12.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0.972549 0.972549 0.94902 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Monaco - 12.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.156863 0.164706 0.211765 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.266667 0.278431 0.352941 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.545098 0.913725 0.992157 1</string>
+	<key>DVTMarkupTextBackgroundColor</key>
+	<string>0.188245 0.192381 0.226996 1</string>
+	<key>DVTMarkupTextBorderColor</key>
+	<string>0.253186 0.25699 0.288836 1</string>
+	<key>DVTMarkupTextCodeFont</key>
+	<string>Monaco - 11.0</string>
+	<key>DVTMarkupTextEmphasisColor</key>
+	<string>0.877929 0.872979 0.878041 1</string>
+	<key>DVTMarkupTextEmphasisFont</key>
+	<string>.AppleSystemUIFontItalic - 11.0</string>
+	<key>DVTMarkupTextInlineCodeColor</key>
+	<string>0.877929 0.872979 0.878041 0.7</string>
+	<key>DVTMarkupTextLinkColor</key>
+	<string>0.384314 0.447059 0.643137 1</string>
+	<key>DVTMarkupTextLinkFont</key>
+	<string>.AppleSystemUIFont - 11.0</string>
+	<key>DVTMarkupTextNormalColor</key>
+	<string>0.877929 0.872979 0.878041 1</string>
+	<key>DVTMarkupTextNormalFont</key>
+	<string>.AppleSystemUIFont - 11.0</string>
+	<key>DVTMarkupTextOtherHeadingColor</key>
+	<string>0.877929 0.872979 0.878041 0.5</string>
+	<key>DVTMarkupTextOtherHeadingFont</key>
+	<string>.AppleSystemUIFont - 15.4</string>
+	<key>DVTMarkupTextPrimaryHeadingColor</key>
+	<string>0.877929 0.872979 0.878041 1</string>
+	<key>DVTMarkupTextPrimaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 26.4</string>
+	<key>DVTMarkupTextSecondaryHeadingColor</key>
+	<string>0.877929 0.872979 0.878041 1</string>
+	<key>DVTMarkupTextSecondaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 19.8</string>
+	<key>DVTMarkupTextStrongColor</key>
+	<string>0.877929 0.872979 0.878041 1</string>
+	<key>DVTMarkupTextStrongFont</key>
+	<string>.AppleSystemUIFontEmphasized - 11.0</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.156863 0.164706 0.211765 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.266667 0.278431 0.352941 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.496379 0.5 0.5 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.266667 0.278431 0.352941 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
 	<dict>
-		<key>DVTConsoleDebuggerInputTextColor</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>DVTConsoleDebuggerInputTextFont</key>
-		<string>Monaco - 12.0</string>
-		<key>DVTConsoleDebuggerOutputTextColor</key>
-		<string>0.972549 0.972549 0.94902 1</string>
-		<key>DVTConsoleDebuggerOutputTextFont</key>
-		<string>Monaco - 12.0</string>
-		<key>DVTConsoleDebuggerPromptTextColor</key>
+		<key>xcode.syntax.attribute</key>
 		<string>0.313725 0.980392 0.482353 1</string>
-		<key>DVTConsoleDebuggerPromptTextFont</key>
-		<string>Monaco - 12.0</string>
-		<key>DVTConsoleExectuableInputTextColor</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>DVTConsoleExectuableInputTextFont</key>
-		<string>Monaco - 12.0</string>
-		<key>DVTConsoleExectuableOutputTextColor</key>
-		<string>0.972549 0.972549 0.94902 1</string>
-		<key>DVTConsoleExectuableOutputTextFont</key>
-		<string>Monaco - 12.0</string>
-		<key>DVTConsoleTextBackgroundColor</key>
-		<string>0.156863 0.164706 0.211765 1</string>
-		<key>DVTConsoleTextInsertionPointColor</key>
-		<string>1 1 1 1</string>
-		<key>DVTConsoleTextSelectionColor</key>
-		<string>0.266667 0.278431 0.352941 1</string>
-		<key>DVTDebuggerInstructionPointerColor</key>
-		<string>0.545098 0.913725 0.992157 1</string>
-		<key>DVTMarkupTextBackgroundColor</key>
-		<string>0.188245 0.192381 0.226996 1</string>
-		<key>DVTMarkupTextBorderColor</key>
-		<string>0.253186 0.25699 0.288836 1</string>
-		<key>DVTMarkupTextCodeFont</key>
-		<string>Monaco - 11.0</string>
-		<key>DVTMarkupTextEmphasisColor</key>
-		<string>0.877929 0.872979 0.878041 1</string>
-		<key>DVTMarkupTextEmphasisFont</key>
-		<string>.AppleSystemUIFontItalic - 11.0</string>
-		<key>DVTMarkupTextInlineCodeColor</key>
-		<string>0.877929 0.872979 0.878041 0.7</string>
-		<key>DVTMarkupTextLinkColor</key>
+		<key>xcode.syntax.character</key>
+		<string>0.741176 0.576471 0.976471 1</string>
+		<key>xcode.syntax.comment</key>
 		<string>0.384314 0.447059 0.643137 1</string>
-		<key>DVTMarkupTextLinkFont</key>
-		<string>.AppleSystemUIFont - 11.0</string>
-		<key>DVTMarkupTextNormalColor</key>
-		<string>0.877929 0.872979 0.878041 1</string>
-		<key>DVTMarkupTextNormalFont</key>
-		<string>.AppleSystemUIFont - 11.0</string>
-		<key>DVTMarkupTextOtherHeadingColor</key>
-		<string>0.877929 0.872979 0.878041 0.5</string>
-		<key>DVTMarkupTextOtherHeadingFont</key>
-		<string>.AppleSystemUIFont - 15.4</string>
-		<key>DVTMarkupTextPrimaryHeadingColor</key>
-		<string>0.877929 0.872979 0.878041 1</string>
-		<key>DVTMarkupTextPrimaryHeadingFont</key>
-		<string>.AppleSystemUIFont - 26.4</string>
-		<key>DVTMarkupTextSecondaryHeadingColor</key>
-		<string>0.877929 0.872979 0.878041 1</string>
-		<key>DVTMarkupTextSecondaryHeadingFont</key>
-		<string>.AppleSystemUIFont - 19.8</string>
-		<key>DVTMarkupTextStrongColor</key>
-		<string>0.877929 0.872979 0.878041 1</string>
-		<key>DVTMarkupTextStrongFont</key>
-		<string>.AppleSystemUIFontEmphasized - 11.0</string>
-		<key>DVTSourceTextBackground</key>
-		<string>0.156863 0.164706 0.211765 1</string>
-		<key>DVTSourceTextBlockDimBackgroundColor</key>
-		<string>0.5 0.5 0.5 1</string>
-		<key>DVTSourceTextCurrentLineHighlightColor</key>
-		<string>0.266667 0.278431 0.352941 1</string>
-		<key>DVTSourceTextInsertionPointColor</key>
-		<string>1 1 1 1</string>
-		<key>DVTSourceTextInvisiblesColor</key>
-		<string>0.496379 0.5 0.5 1</string>
-		<key>DVTSourceTextSelectionColor</key>
-		<string>0.266667 0.278431 0.352941 1</string>
-		<key>DVTSourceTextSyntaxColors</key>
-		<dict>
-			<key>xcode.syntax.attribute</key>
-			<string>0.313725 0.980392 0.482353 1</string>
-			<key>xcode.syntax.character</key>
-			<string>0.741176 0.576471 0.976471 1</string>
-			<key>xcode.syntax.comment</key>
-			<string>0.384314 0.447059 0.643137 1</string>
-			<key>xcode.syntax.comment.doc</key>
-			<string>0.384314 0.447059 0.643137 1</string>
-			<key>xcode.syntax.comment.doc.keyword</key>
-			<string>0.384314 0.447059 0.643137 1</string>
-			<key>xcode.syntax.identifier.class</key>
-			<string>0.313725 0.980392 0.482353 1</string>
-			<key>xcode.syntax.identifier.class.system</key>
-			<string>0.313725 0.980392 0.482353 1</string>
-			<key>xcode.syntax.identifier.constant</key>
-			<string>0.741176 0.576471 0.976471 1</string>
-			<key>xcode.syntax.identifier.constant.system</key>
-			<string>0.741176 0.576471 0.976471 1</string>
-			<key>xcode.syntax.identifier.function</key>
-			<string>0.313725 0.980392 0.482353 1</string>
-			<key>xcode.syntax.identifier.function.system</key>
-			<string>0.313725 0.980392 0.482353 1</string>
-			<key>xcode.syntax.identifier.macro</key>
-			<string>0.945098 0.980392 0.54902 1</string>
-			<key>xcode.syntax.identifier.macro.system</key>
-			<string>0.945098 0.980392 0.54902 1</string>
-			<key>xcode.syntax.identifier.type</key>
-			<string>1 0.721569 0.423529 1</string>
-			<key>xcode.syntax.identifier.type.system</key>
-			<string>1 0.721569 0.423529 1</string>
-			<key>xcode.syntax.identifier.variable</key>
-			<string>0.545098 0.913725 0.992157 1</string>
-			<key>xcode.syntax.identifier.variable.system</key>
-			<string>0.545098 0.913725 0.992157 1</string>
-			<key>xcode.syntax.keyword</key>
-			<string>1 0.47451 0.776471 1</string>
-			<key>xcode.syntax.number</key>
-			<string>0.741176 0.576471 0.976471 1</string>
-			<key>xcode.syntax.plain</key>
-			<string>0.972549 0.972549 0.94902 1</string>
-			<key>xcode.syntax.preprocessor</key>
-			<string>0.945098 0.980392 0.54902 1</string>
-			<key>xcode.syntax.string</key>
-			<string>0.945098 0.980392 0.54902 1</string>
-			<key>xcode.syntax.url</key>
-			<string>0.741176 0.576471 0.976471 1</string>
-		</dict>
-		<key>DVTSourceTextSyntaxFonts</key>
-		<dict>
-			<key>xcode.syntax.attribute</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.character</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.comment</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.comment.doc</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.comment.doc.keyword</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.class</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.class.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.constant</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.constant.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.function</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.function.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.macro</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.macro.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.type</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.type.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.variable</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.identifier.variable.system</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.keyword</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.number</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.plain</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.preprocessor</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.string</key>
-			<string>Monaco - 12.0</string>
-			<key>xcode.syntax.url</key>
-			<string>Monaco - 12.0</string>
-		</dict>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.384314 0.447059 0.643137 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.384314 0.447059 0.643137 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.313725 0.980392 0.482353 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.313725 0.980392 0.482353 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.741176 0.576471 0.976471 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.741176 0.576471 0.976471 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.313725 0.980392 0.482353 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.313725 0.980392 0.482353 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.945098 0.980392 0.54902 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.945098 0.980392 0.54902 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>1 0.721569 0.423529 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>1 0.721569 0.423529 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.545098 0.913725 0.992157 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.545098 0.913725 0.992157 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>1 0.47451 0.776471 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.741176 0.576471 0.976471 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.972549 0.972549 0.94902 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.945098 0.980392 0.54902 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.945098 0.980392 0.54902 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.741176 0.576471 0.976471 1</string>
 	</dict>
-	</plist>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Monaco - 12.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Monaco - 12.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Changed theme colors to make it more compatible with Swift syntax. Let me know if I missed some color.

Here's a preview:
![screen shot 2016-10-12 at 19 57 12](https://cloud.githubusercontent.com/assets/520117/19330734/8b0a9c58-90b6-11e6-9e26-22a9d3b7d59b.png)
