### PR TITLE
Support latest Xcode

### DIFF
--- a/Dracula.xccolortheme
+++ b/Dracula.xccolortheme
@@ -1,0 +1,1 @@
+Dracula.dvtcolortheme


### PR DESCRIPTION
Since Xcode 8, color scheme extension is modified to `xccolortheme`.
So creating symlink to `.dvtcolortheme`.

If you want to use this theme on Xcode 8 or later, Use `xccolortheme` instead of `dvtcolortheme`.