### PR TITLE
Update INSTALL.md with Xcode 27 theme instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,3 +37,13 @@ mkdir ~/Library/Developer/Xcode/UserData/FontAndColorThemes
 
 1. Open _Xcode > Preferences > Themes_
 2. Select Dracula Theme
+
+**For Xcode 27+**
+
+1. In the menu bar: `Xcode -> Settings -> Appearance -> Theme`;
+2. Next to `Theme`, click **Choose**
+3. Click **Import** on the bottom
+4. Find and select the `Dracula.xccolortheme` or `Alucard.xccolortheme` files
+5. Keep *Colors* and *Fonts* toggled **ON**
+6. Click **Import**
+7. Enjoy!


### PR DESCRIPTION
Added installation steps for Xcode 27+ theme.

Beginning with Xcode 27.0 beta, Apple introduced a new theme import workflow. Custom themes must now be imported via Xcode → Settings → Themes → Import… instead of being installed manually in the FontAndColorThemes folder.